### PR TITLE
Missing isort in pip

### DIFF
--- a/app/pip/2.7/requirements.txt
+++ b/app/pip/2.7/requirements.txt
@@ -1,9 +1,10 @@
-twine
-wheel
 bandit
 flake8
+isort
 pylint
 pytest
 pytest-azurepipelines42
 pytest-cov
 pytest-xdist
+twine
+wheel

--- a/app/pip/3.4/requirements.txt
+++ b/app/pip/3.4/requirements.txt
@@ -1,9 +1,10 @@
-twine
-wheel
 bandit
 flake8
+isort
 pylint
 pytest
 pytest-azurepipelines42
 pytest-cov
 pytest-xdist
+twine
+wheel

--- a/app/pip/3.5/requirements.txt
+++ b/app/pip/3.5/requirements.txt
@@ -1,9 +1,10 @@
-twine
-wheel
 bandit
 flake8
+isort
 pylint
 pytest
 pytest-azurepipelines42
 pytest-cov
 pytest-xdist
+twine
+wheel

--- a/app/pip/3.6/requirements.txt
+++ b/app/pip/3.6/requirements.txt
@@ -1,9 +1,10 @@
-twine
-wheel
 bandit
 flake8
+isort
 pylint
 pytest
 pytest-azurepipelines42
 pytest-cov
 pytest-xdist
+twine
+wheel

--- a/app/pip/3.7/requirements.txt
+++ b/app/pip/3.7/requirements.txt
@@ -1,9 +1,10 @@
-twine
-wheel
 bandit
 flake8
+isort
 pylint
 pytest
 pytest-azurepipelines42
 pytest-cov
 pytest-xdist
+twine
+wheel


### PR DESCRIPTION
<!--
Thank you for your contribution to the pademelon repository. 
Your code will need to pass the automated checks before merging.
Before submitting this PR, please make sure:
-->
- [ ] You have added unit tests
- [ ] You have updated the documentation if applicable
